### PR TITLE
expose other branches as dev-branchname

### DIFF
--- a/composer.go
+++ b/composer.go
@@ -167,11 +167,9 @@ func (c *ComposerRepository) refreshProjectReference(p *Project, r *Reference) {
 }
 
 func (c *ComposerRepository) parseVersion(r string) string {
-	if r == "master" {
-		return "dev-master"
-	} else if c.versionRegexp.MatchString(r) {
+	if c.versionRegexp.MatchString(r) {
 		return r
 	}
 
-	return ""
+	return "dev-"+r
 }


### PR DESCRIPTION
Composer supports other branches then master only prefixing them with dev-{branchname}
see https://getcomposer.org/doc/02-libraries.md#branches
